### PR TITLE
Refactor to run on MAC OS

### DIFF
--- a/banking_dashboard/min-requirements.txt
+++ b/banking_dashboard/min-requirements.txt
@@ -1,0 +1,13 @@
+backoff-utils==1.0.1
+census-geocoder==0.1.0
+numpy==1.24.3
+openpyxl==3.0.10
+pandas==1.5.3
+requests==2.26.0
+tqdm==4.65.0
+validator-collection==1.5.0
+wget==3.2
+zipcodes==1.2.0
+jupyter==1.0.0
+ipykernel==6.19.2
+ipywidgets==8.0.4


### PR DESCRIPTION
This PR makes the following changes:

- Use `min-requirements.txt` file to support cross-platform installation
- Minor adjustments to helper functions to account for cross-platform use
- Programmatically download FFIEC, HMDA, and FDIC data sources to year-specific data path
- Resolve regex warning in HMDA ingestion